### PR TITLE
Remove .AI namespacing on NavMeshAgent calls

### DIFF
--- a/Assets/MapzenGo/Standard Assets/Characters/ThirdPersonCharacter/Scripts/AICharacterControl.cs
+++ b/Assets/MapzenGo/Standard Assets/Characters/ThirdPersonCharacter/Scripts/AICharacterControl.cs
@@ -3,11 +3,11 @@ using UnityEngine;
 
 namespace UnityStandardAssets.Characters.ThirdPerson
 {
-    [RequireComponent(typeof (UnityEngine.AI.NavMeshAgent))]
+    [RequireComponent(typeof (UnityEngine.NavMeshAgent))]
     [RequireComponent(typeof (ThirdPersonCharacter))]
     public class AICharacterControl : MonoBehaviour
     {
-        public UnityEngine.AI.NavMeshAgent agent { get; private set; }             // the navmesh agent required for the path finding
+        public UnityEngine.NavMeshAgent agent { get; private set; }             // the navmesh agent required for the path finding
         public ThirdPersonCharacter character { get; private set; } // the character we are controlling
         public Transform target;                                    // target to aim for
 
@@ -15,7 +15,7 @@ namespace UnityStandardAssets.Characters.ThirdPerson
         private void Start()
         {
             // get the components on the object we need ( should not be null due to require component so no need to check )
-            agent = GetComponentInChildren<UnityEngine.AI.NavMeshAgent>();
+            agent = GetComponentInChildren<UnityEngine.NavMeshAgent>();
             character = GetComponent<ThirdPersonCharacter>();
 
 	        agent.updateRotation = false;


### PR DESCRIPTION
The .AI namespace has changed as of Unity 5.3x if not earlier which causes the application not to run.  Removing .AI solved this issue.